### PR TITLE
Documantation to chek synapse version

### DIFF
--- a/UPGRADE.rst
+++ b/UPGRADE.rst
@@ -28,6 +28,15 @@ running:
     git pull
     # Update the versions of synapse's python dependencies.
     python synapse/python_dependencies.py | xargs -n1 pip install --upgrade
+	
+To check whether your update was sucessfull, run:
+
+.. code:: bash
+
+	 # replace your.server.domain with ther domain of your synaspe homeserver
+	 curl https://<your.server.domain>/_matrix/federation/v1/version 
+
+So for the Matrix.org HS server the URL would be: https://matrix.org/_matrix/federation/v1/version.
 
 
 Upgrading to v0.15.0


### PR DESCRIPTION
I've added some Documentation, how to get the running Version of a
Synapse homeserver. This should help the HS-Owners to check whether the
Upgrade was successful.